### PR TITLE
Use correct value for default username in database

### DIFF
--- a/r-users.tf
+++ b/r-users.tf
@@ -14,7 +14,7 @@ module "databases_users" {
   sql_server_hostname = azurerm_mssql_server.sql.fully_qualified_domain_name
 
   database_name = each.value.database
-  user_name     = each.key
+  user_name     = each.value.username
   user_roles    = each.value.roles
 }
 


### PR DESCRIPTION
The module uses a the `for_each` key as the default username in target database which is not correct. This is also different from what appears in the output connection string;

This PR fixes the code to use correct attribute of the local.database_users for username.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request
- Use the correct value for username

@claranet/fr-azure-reviewers
