### PR TITLE
Unhardcode SQL server identity

### DIFF
--- a/r-sql.tf
+++ b/r-sql.tf
@@ -22,8 +22,12 @@ resource "azurerm_mssql_server" "main" {
     }
   }
 
-  identity {
-    type = "SystemAssigned"
+  dynamic "identity" {
+    for_each = var.identity_type[*]
+    content {
+      type         = var.identity_type
+      identity_ids = endswith(var.identity_type, "UserAssigned") ? var.identity_ids : null
+    }
   }
 
   tags = merge(local.default_tags, var.extra_tags, var.server_extra_tags)

--- a/variables.tf
+++ b/variables.tf
@@ -320,3 +320,17 @@ variable "security_storage_account_container_name" {
   type        = string
   default     = null
 }
+
+# Identity
+
+variable "identity_type" {
+  description = "Specifies the type of Managed Service Identity that should be configured on this SQL Server. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both)."
+  type        = string
+  default     = "SystemAssigned"
+}
+
+variable "identity_ids" {
+  description = "Specifies a list of User Assigned Managed Identity IDs to be assigned to this SQL Server."
+  type        = list(string)
+  default     = null
+}


### PR DESCRIPTION
Fixes #7.

Option to modify identity exists in `azurerm_mssql_server` [resource](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server#type-1)

However, it's hardcoded to `SystemAssigned` identity [in the module](https://github.com/claranet/terraform-azurerm-db-sql/blob/master/r-sql.tf#L25-L27).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- parametrize SQL server identity to pass it to module as variables (like in other claranet modules, e.g., for [storage account](https://github.com/claranet/terraform-azurerm-storage-account/blob/master/r-storage-account.tf#L30-L36))

@claranet/fr-azure-reviewers
