### PR TITLE
fix: parametrize SQL DB identity

### DIFF
--- a/r-db.tf
+++ b/r-db.tf
@@ -28,6 +28,14 @@ resource "azurerm_mssql_database" "single_database" {
 
   storage_account_type = each.value.storage_account_type
 
+  dynamic "identity" {
+    for_each = each.value.identity_type[*]
+    content {
+      type         = each.value.identity_type
+      identity_ids = endswith(each.value.identity_type, "UserAssigned") ? each.value.identity_ids : null
+    }
+  }
+
   dynamic "threat_detection_policy" {
     for_each = var.threat_detection_policy_enabled ? ["enabled"] : []
     content {
@@ -90,6 +98,14 @@ resource "azurerm_mssql_database" "elastic_pool_database" {
   read_replica_count = startswith(local.elastic_pool_sku.name, "HS") ? each.value.read_replica_count : null
 
   storage_account_type = each.value.storage_account_type
+
+  dynamic "identity" {
+    for_each = each.value.identity_type[*]
+    content {
+      type         = each.value.identity_type
+      identity_ids = endswith(each.value.identity_type, "UserAssigned") ? each.value.identity_ids : null
+    }
+  }
 
   dynamic "threat_detection_policy" {
     for_each = var.threat_detection_policy_enabled ? ["enabled"] : []

--- a/r-db.tf
+++ b/r-db.tf
@@ -29,7 +29,7 @@ resource "azurerm_mssql_database" "single_database" {
   storage_account_type = each.value.storage_account_type
 
   dynamic "identity" {
-    for_each = each.value.identity_ids != null ? length(each.value.identity_ids) > 0 ? ["UserAssigned"] : [] : []
+    for_each = length(each.value.identity_ids) > 0 ? ["UserAssigned"] : []
     content {
       type         = "UserAssigned"
       identity_ids = each.value.identity_ids
@@ -100,7 +100,7 @@ resource "azurerm_mssql_database" "elastic_pool_database" {
   storage_account_type = each.value.storage_account_type
 
   dynamic "identity" {
-    for_each = each.value.identity_ids != null ? length(each.value.identity_ids) > 0 ? ["UserAssigned"] : [] : []
+    for_each = length(each.value.identity_ids) > 0 ? ["UserAssigned"] : []
     content {
       type         = "UserAssigned"
       identity_ids = each.value.identity_ids

--- a/r-db.tf
+++ b/r-db.tf
@@ -29,7 +29,7 @@ resource "azurerm_mssql_database" "single_database" {
   storage_account_type = each.value.storage_account_type
 
   dynamic "identity" {
-    for_each = length(try(each.value.identity_ids, [])) > 0 ? ["UserAssigned"] : []
+    for_each = each.value.identity_ids != null ? length(each.value.identity_ids) > 0 ? ["UserAssigned"] : [] : []
     content {
       type         = "UserAssigned"
       identity_ids = each.value.identity_ids
@@ -100,7 +100,7 @@ resource "azurerm_mssql_database" "elastic_pool_database" {
   storage_account_type = each.value.storage_account_type
 
   dynamic "identity" {
-    for_each = length(try(each.value.identity_ids, [])) > 0 ? ["UserAssigned"] : []
+    for_each = each.value.identity_ids != null ? length(each.value.identity_ids) > 0 ? ["UserAssigned"] : [] : []
     content {
       type         = "UserAssigned"
       identity_ids = each.value.identity_ids

--- a/r-db.tf
+++ b/r-db.tf
@@ -29,10 +29,10 @@ resource "azurerm_mssql_database" "single_database" {
   storage_account_type = each.value.storage_account_type
 
   dynamic "identity" {
-    for_each = each.value.identity_type[*]
+    for_each = length(try(each.value.identity_ids, [])) > 0 ? ["UserAssigned"] : []
     content {
-      type         = each.value.identity_type
-      identity_ids = endswith(each.value.identity_type, "UserAssigned") ? each.value.identity_ids : null
+      type         = "UserAssigned"
+      identity_ids = each.value.identity_ids
     }
   }
 
@@ -100,10 +100,10 @@ resource "azurerm_mssql_database" "elastic_pool_database" {
   storage_account_type = each.value.storage_account_type
 
   dynamic "identity" {
-    for_each = each.value.identity_type[*]
+    for_each = length(try(each.value.identity_ids, [])) > 0 ? ["UserAssigned"] : []
     content {
-      type         = each.value.identity_type
-      identity_ids = endswith(each.value.identity_type, "UserAssigned") ? each.value.identity_ids : null
+      type         = "UserAssigned"
+      identity_ids = each.value.identity_ids
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -148,6 +148,8 @@ variable "databases" {
     name                        = string
     license_type                = optional(string)
     sku_name                    = optional(string)
+    identity_type               = optional(string)
+    identity_ids                = optional(list(string))
     max_size_gb                 = optional(number)
     create_mode                 = optional(string)
     min_capacity                = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -148,7 +148,7 @@ variable "databases" {
     name                        = string
     license_type                = optional(string)
     sku_name                    = optional(string)
-    identity_ids                = optional(list(string))
+    identity_ids                = optional(list(string), [])
     max_size_gb                 = optional(number)
     create_mode                 = optional(string)
     min_capacity                = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -148,7 +148,6 @@ variable "databases" {
     name                        = string
     license_type                = optional(string)
     sku_name                    = optional(string)
-    identity_type               = optional(string)
     identity_ids                = optional(list(string))
     max_size_gb                 = optional(number)
     create_mode                 = optional(string)


### PR DESCRIPTION
Follow-up on https://github.com/claranet/terraform-azurerm-db-sql/pull/8.

DBs also have identity block in `azurerm_mssql_database` ([ref](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database#type-1)).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- parametrize SQL DB identity to pass it to module as variables (like in other claranet modules, e.g., for [storage account](https://github.com/claranet/terraform-azurerm-storage-account/blob/master/r-storage-account.tf#L30-L36))

@claranet/fr-azure-reviewers
