### PR TITLE
Add missing primary_user_assigned_identity_id parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ module "sql_single" {
 | outbound\_network\_restriction\_enabled | Whether outbound network traffic is restricted for this server. | `bool` | `false` | no |
 | point\_in\_time\_backup\_interval\_in\_hours | The hours between each differential backup. This is only applicable to live databases but not dropped databases. Value has to be 12 or 24. Defaults to 12 hours. | `number` | `12` | no |
 | point\_in\_time\_restore\_retention\_days | Point In Time Restore configuration. Value has to be between `7` and `35`. | `number` | `7` | no |
+| primary\_user\_assigned\_identity\_id | Specifies the primary user managed identity id. Required if type within the identity block is set to either SystemAssigned, UserAssigned or UserAssigned and should be set at same time as setting identity\_ids. | `string` | `null` | no |
 | public\_network\_access\_enabled | True to allow public network access for this server. | `bool` | `false` | no |
 | resource\_group\_name | Resource group name. | `string` | n/a | yes |
 | security\_storage\_account\_access\_key | Storage Account access key used to store security logs and reports. | `string` | `null` | no |

--- a/r-db.tf
+++ b/r-db.tf
@@ -79,7 +79,7 @@ resource "azurerm_mssql_database" "main" {
   dynamic "short_term_retention_policy" {
     # For elastic pool databases, exclude the block for HS SKUs
     # For single databases, always include the block
-    for_each = var.elastic_pool_enabled && startswith(local.elastic_pool_sku.name, "HS") ? [] : ["enabled"]
+    for_each = var.elastic_pool_enabled && try(startswith(local.elastic_pool_sku.name, "HS"), false) ? [] : ["enabled"]
     content {
       retention_days = var.point_in_time_restore_retention_days
       # backup_interval_in_hours is only supported for elastic pool databases

--- a/r-sql.tf
+++ b/r-sql.tf
@@ -22,6 +22,8 @@ resource "azurerm_mssql_server" "main" {
     }
   }
 
+  primary_user_assigned_identity_id = var.primary_user_assigned_identity_id
+
   dynamic "identity" {
     for_each = var.identity[*]
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -333,7 +333,7 @@ variable "identity" {
 }
 
 variable "primary_user_assigned_identity_id" {
-  description = "Specifies the primary user managed identity id. Required if type within the identity block is set to either SystemAssigned, UserAssigned or UserAssigned and should be set at same time as setting identity_ids"
+  description = "Specifies the primary user managed identity id. Required if type within the identity block is set to either SystemAssigned, UserAssigned or UserAssigned and should be set at same time as setting identity_ids."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -331,3 +331,9 @@ variable "identity" {
   default  = {}
   nullable = false
 }
+
+variable "primary_user_assigned_identity_id" {
+  description = "Specifies the primary user managed identity id. Required if type within the identity block is set to either SystemAssigned, UserAssigned or UserAssigned and should be set at same time as setting identity_ids"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Follow-up on https://github.com/claranet/terraform-azurerm-db-sql/pull/8.

Add missing `primary_user_assigned_identity_id` parameter required for `UserAssigned` identity. [Reference](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server#primary_user_assigned_identity_id-1).

Fixes #(issue) .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- Add `primary_user_assigned_identity_id` parameter required for `UserAssigned` identity

@claranet/fr-azure-reviewers
